### PR TITLE
Port Fabric build to Minecraft 26.1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,51 +1,60 @@
 plugins {
-    id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.9-SNAPSHOT" apply false
+    id "net.fabricmc.fabric-loom" version "1.16-SNAPSHOT"
+    id "maven-publish"
 }
 
-architectury {
-    minecraft = rootProject.minecraft_version
+version = project.mod_version
+group = project.maven_group
+
+base {
+    archivesName = project.archives_base_name
 }
 
-subprojects {
-    apply plugin: "dev.architectury.loom"
+repositories {
+}
 
-    loom {
-        silentMojangMappingsLicense()
-    }
+dependencies {
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    implementation "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+}
 
-    dependencies {
-        minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
-        // The following line declares the mojmap mappings, you may use other mappings as well
-        mappings loom.officialMojangMappings()
-        // The following line declares the yarn mappings you may select this one as well.
-        // mappings "net.fabricmc:yarn:@YARN_MAPPINGS@:v2"
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = "UTF-8"
+    options.release.set(25)
+}
+
+java {
+    withSourcesJar()
+
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
+}
+
+processResources {
+    def version = project.version
+
+    inputs.property "version", version
+
+    filesMatching("fabric.mod.json") {
+        expand "version": version
     }
 }
 
-allprojects {
-    apply plugin: "java"
-    apply plugin: "architectury-plugin"
-    apply plugin: "maven-publish"
+sourceSets {
+    main {
+        java {
+            srcDirs = [
+                "common/src/main/java",
+                "fabric/src/main/java"
+            ]
+        }
 
-    archivesBaseName = rootProject.archives_base_name
-    version = rootProject.mod_version
-    group = rootProject.maven_group
-
-    repositories {
-        // Add repositories to retrieve artifacts from in here.
-        // You should only use this when depending on other mods because
-        // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-        // See https://docs.gradle.org/current/userguide/declaring_repositories.html
-        // for more information about repositories.
-    }
-
-    tasks.withType(JavaCompile) {
-        options.encoding = "UTF-8"
-        options.release.set(17)
-    }
-
-    java {
-        withSourcesJar()
+        resources {
+            srcDirs = [
+                "common/src/main/resources",
+                "fabric/src/main/resources"
+            ]
+        }
     }
 }

--- a/common/src/main/java/io/github/tigercrl/norealmsbutton/mixin/OnlineOptionsScreenMixin.java
+++ b/common/src/main/java/io/github/tigercrl/norealmsbutton/mixin/OnlineOptionsScreenMixin.java
@@ -5,7 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.OptionInstance;
 import net.minecraft.client.Options;
-import net.minecraft.client.gui.screens.OnlineOptionsScreen;
+import net.minecraft.client.gui.screens.options.OnlineOptionsScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 

--- a/fabric/src/main/java/io/github/tigercrl/norealmsbutton/fabric/NoRealmsButtonFabricClient.java
+++ b/fabric/src/main/java/io/github/tigercrl/norealmsbutton/fabric/NoRealmsButtonFabricClient.java
@@ -3,39 +3,54 @@ package io.github.tigercrl.norealmsbutton.fabric;
 import io.github.tigercrl.norealmsbutton.NoRealmsButton;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
-import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.fabricmc.fabric.api.event.Event;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.PlainTextButton;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class NoRealmsButtonFabricClient implements ClientModInitializer {
-    public static final ResourceLocation REALMS_REMOVE_PHACE = new ResourceLocation(NoRealmsButton.MOD_ID, "realms_remove");
+    public static final Identifier REALMS_REMOVE_PHASE = Identifier.fromNamespaceAndPath(NoRealmsButton.MOD_ID, "realms_remove");
 
     @Override
     public void onInitializeClient() {
-        // run after other listeners
-        ScreenEvents.AFTER_INIT.addPhaseOrdering(Event.DEFAULT_PHASE, REALMS_REMOVE_PHACE);
+        // Run after other listeners.
+        ScreenEvents.AFTER_INIT.addPhaseOrdering(Event.DEFAULT_PHASE, REALMS_REMOVE_PHASE);
 
-        ScreenEvents.AFTER_INIT.register(REALMS_REMOVE_PHACE, (minecraft, s, scaledWidth, scaledHeight) -> {
-            if (!(s instanceof TitleScreen)) return;
-            List<AbstractWidget> buttons = Screens.getButtons(s);
+        ScreenEvents.AFTER_INIT.register(REALMS_REMOVE_PHASE, (minecraft, screen, scaledWidth, scaledHeight) -> {
+            if (!(screen instanceof TitleScreen)) {
+                return;
+            }
 
-            Button realmsButton = null;
-            for (AbstractWidget b : buttons) {
-                if (realmsButton != null && b.getY() >= realmsButton.getY() && !(b instanceof PlainTextButton) && b.visible) {
-                    b.setY(b.getY() - 24);
-                }
-                if (b.getMessage().equals(Component.translatable("menu.online"))) {
-                    realmsButton = (Button) b;
+            List<AbstractWidget> buttons = new ArrayList<>();
+
+            for (var child : screen.children()) {
+                if (child instanceof AbstractWidget widget) {
+                    buttons.add(widget);
                 }
             }
-            if (realmsButton != null) buttons.remove(realmsButton);
+
+            Button realmsButton = null;
+
+            for (AbstractWidget button : buttons) {
+                if (realmsButton != null && button.getY() >= realmsButton.getY() && !(button instanceof PlainTextButton) && button.visible) {
+                    button.setY(button.getY() - 24);
+                }
+
+                if (button.getMessage().equals(Component.translatable("menu.online")) && button instanceof Button matchedButton) {
+                    realmsButton = matchedButton;
+                }
+            }
+
+            if (realmsButton != null) {
+                realmsButton.visible = false;
+                realmsButton.active = false;
+            }
         });
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,8 +25,8 @@
     "norealmsbutton.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.16.0",
-    "fabric-api": "*",
-    "minecraft": "~1.20-1.20.6"
+      "fabricloader": ">=0.19.2",
+      "fabric-api": "*",
+      "minecraft": ">=26.1.0 <26.2.0"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,11 @@
 org.gradle.jvmargs=-Xmx3G
+org.gradle.configuration-cache=false
 
-minecraft_version=1.20.1
-enabled_platforms=fabric,forge
+minecraft_version=26.1.2
 
 archives_base_name=NoRealmsButton
-mod_version=2.0.2
+mod_version=2.0.3-26.1.x
 maven_group=io.github.tigercrl
 
-fabric_loader_version=0.16.14
-fabric_api_version=0.92.6+1.20.1
-
-forge_version=1.20.1-47.4.0
+fabric_loader_version=0.19.2
+fabric_api_version=0.148.2+26.1.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,12 @@
 pluginManagement {
     repositories {
-        maven { url "https://maven.fabricmc.net/" }
-        maven { url "https://maven.architectury.dev/" }
-        maven { url "https://maven.minecraftforge.net/" }
+        maven {
+            name = "Fabric"
+            url = "https://maven.fabricmc.net/"
+        }
+        mavenCentral()
         gradlePluginPortal()
     }
 }
 
-include("common")
-include("fabric")
-include("forge")
+rootProject.name = "NoRealmsButton"


### PR DESCRIPTION
Ports the Fabric build to Minecraft 26.1.x.

Changes:
- Converted the build to the current Fabric Loom setup for Minecraft 26.1.x.
- Updated Gradle wrapper to Gradle 9.4.0.
- Updated Java target to Java 25.
- Updated Fabric Loader and Fabric API versions.
- Updated `fabric.mod.json` Minecraft dependency range for 26.1.x.
- Updated `OnlineOptionsScreenMixin` import for the new screen package.
- Replaced removed `Screens.getButtons()` usage with `screen.children()`.
- Disabled the Realms title screen button instead of calling protected `removeWidget()`.

Tested:
- Builds successfully with Gradle.
- Tested in Minecraft 26.1.2.
- Mod loads successfully.
- Realms button is removed from the title screen.